### PR TITLE
Add exit_unknown_on_exception decorator.

### DIFF
--- a/simple_icinga_plugin/__init__.py
+++ b/simple_icinga_plugin/__init__.py
@@ -108,3 +108,10 @@ def exit_warning(msg, **kwargs):
     All additional arguments are passed as is to the msg.format() method.
     '''
     plugin_exit(msg, prefix='WARNING', code=1, **kwargs)
+
+def exit_unknown_on_exception(func):
+    '''Decorator that will exit with unknown state if an exception occurs.'''
+    try:
+        return func()
+    except Exception as exc:  # pylint: disable=broad-except
+        exit_unknown("Unhandled exception occured: %s" % (exc, ))


### PR DESCRIPTION
The decorator will cause the program to exit with error code 3
and output the string representation of the exception on stdout.